### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/azuredevelopercollege/6d3bfa7b-e057-499e-8814-51ce24177b3c/2ee84315-30e6-486b-b864-ebcac0c5f64a/_apis/work/boardbadge/f65c2a21-1eb3-448b-910f-aee30608e9d6)](https://dev.azure.com/azuredevelopercollege/6d3bfa7b-e057-499e-8814-51ce24177b3c/_boards/board/t/2ee84315-30e6-486b-b864-ebcac0c5f64a/Microsoft.RequirementCategory)
 # azure-developer-college
 Repository for Azure Developer College Hands-On


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/azuredevelopercollege/6d3bfa7b-e057-499e-8814-51ce24177b3c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.